### PR TITLE
Fix issue when sending messages after the Connected event.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       checks: write
+      pull-requests: write
 
     strategy:
       matrix:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,15 +11,15 @@ on:
     - 'src/**'
     branches: [ main ]
 
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-
-    permissions:
-      checks: write
-      contents: write
-      pull-requests: write
 
     strategy:
       matrix:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       checks: write
+      contents: write
       pull-requests: write
 
     strategy:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,11 +11,11 @@ on:
     - 'src/**'
     branches: [ main ]
 
-permissions:
-  statuses: write
-  checks: write
-  contents: write
-  pull-requests: write
+#permissions:
+#  statuses: write
+#  checks: write
+#  contents: write
+#  pull-requests: write
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,7 @@ on:
     branches: [ main ]
 
 permissions:
+  statuses: write
   checks: write
   contents: write
   pull-requests: write

--- a/src/Nager.TcpClient.UnitTest/SendAfterConnectedEventTest.cs
+++ b/src/Nager.TcpClient.UnitTest/SendAfterConnectedEventTest.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.TcpClient.UnitTest
+{
+    [TestClass]
+    public class SendAfterConnectedEventTest
+    {
+        private async void SendMessage(TcpClient tcpClient)
+        {
+            var data = Encoding.UTF8.GetBytes("ping\n");
+            await tcpClient.SendAsync(data);
+        }
+
+        [TestMethod]
+        public void SendAfterConnect_Successful()
+        {
+            var ipAddress = "tcpbin.com";
+            var port = 4242;
+
+            var mockLoggerTcpClient = LoggerHelper.GetLogger<TcpClient>();
+            using var tcpClient = new TcpClient(logger: mockLoggerTcpClient.Object);
+            tcpClient.Connected += () => SendMessage(tcpClient);
+            tcpClient.Connect(ipAddress, port, 1000);
+
+            mockLoggerTcpClient.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("SendAsync")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task SendAfterConnectAsync_Successful()
+        {
+            var ipAddress = "tcpbin.com";
+            var port = 4242;
+
+            var mockLoggerTcpClient = LoggerHelper.GetLogger<TcpClient>();
+            using var tcpClient = new TcpClient(logger: mockLoggerTcpClient.Object);
+            tcpClient.Connected += () => SendMessage(tcpClient);
+            await tcpClient.ConnectAsync(ipAddress, port);
+
+            mockLoggerTcpClient.Verify(
+                x => x.Log(
+                    LogLevel.Debug,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("SendAsync")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+    }
+}

--- a/src/Nager.TcpClient/Nager.TcpClient.csproj
+++ b/src/Nager.TcpClient/Nager.TcpClient.csproj
@@ -22,7 +22,7 @@
 	  
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6</TargetFrameworks>
 
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nager.TcpClient/TcpClient.cs
+++ b/src/Nager.TcpClient/TcpClient.cs
@@ -285,10 +285,10 @@ namespace Nager.TcpClient
                     waitHandle.Close();
                     waitHandle.Dispose();
 
+                    this.PrepareStream();
+
                     this._logger.LogInformation($"{nameof(Connect)} - Connected");
                     this.SwitchToConnected();
-
-                    this.PrepareStream();
 
                     return true;
                 }
@@ -338,10 +338,11 @@ namespace Nager.TcpClient
                 return false;
             }
 
+            this.PrepareStream();
+
             this._logger.LogInformation($"{nameof(ConnectAsync)} - Connected");
             this.SwitchToConnected();
-
-            this.PrepareStream();
+            
             return true;
         }
 
@@ -400,10 +401,11 @@ namespace Nager.TcpClient
                 return false;
             }
 
+            this.PrepareStream();
+
             this._logger.LogInformation($"{nameof(ConnectAsync)} - Connected");
             this.SwitchToConnected();
 
-            this.PrepareStream();
             return true;
         }
 
@@ -431,6 +433,7 @@ namespace Nager.TcpClient
         {
             if (this._stream == null)
             {
+                this._logger.LogError($"{nameof(SendAsync)} - Stream is null");
                 return;
             }
 


### PR DESCRIPTION
Hello! Thank you for this library, it saved me some time with the events and connection management.

However, I'm having an issue because I'm sending a message as soon as the Connected event is triggered, and looking at the source code I found that's because the Stream gets prepared only after the event is triggered. To fix that, the only thing I had to do was to move the call that prepares the Stream to be done before the event gets triggered. I added unit tests for this issue as well.

I also added an error log when we call `SendAsync` without having the Stream ready (same thing you do in the `DataReadAsync` method).